### PR TITLE
Add Docker support for Django project

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.sqlite3
+*.db
+.env
+venv/
+.idea/
+.vscode/
+.git
+.gitignore
+zwg_credit_card_fraud_pipeline.pkl
+zwg_credit_card_fraud_dataset.csv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        g++ \
+        gfortran \
+        libatlas-base-dev \
+        libopenblas-dev \
+        liblapack-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Fraud_Detection/requirements.txt /tmp/requirements.txt
+
+RUN pip install --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt
+
+COPY Fraud_Detection /app
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,42 @@
+# Fraud Detection Project
+
+This repository contains a Django-based fraud detection project. The application can now be run inside Docker for a consistent development environment.
+
+## Prerequisites
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [Docker Compose](https://docs.docker.com/compose/install/) (v2 or later)
+
+## Running the application
+
+1. Build the Docker image and start the service:
+
+   ```bash
+   docker compose up --build
+   ```
+
+2. Visit the application at [http://localhost:8000](http://localhost:8000).
+
+   The entrypoint automatically applies database migrations before the server starts. The default command runs Django's development server which reloads when files change (thanks to the mounted volume).
+
+## Management commands
+
+To run Django management commands inside the container, use `docker compose run` (for one-off commands) or `docker compose exec` (for commands against a running container). Examples:
+
+```bash
+# Run a custom command without starting the web server
+docker compose run --rm web python manage.py createsuperuser
+
+# Open a shell inside the running container
+docker compose exec web /bin/sh
+```
+
+## Testing the image build
+
+You can verify that the Docker image builds successfully without starting the service:
+
+```bash
+docker build -t fraud-detection:latest .
+```
+
+This command uses the Dockerfile to install Python dependencies and prepares the containerized environment.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: "3.9"
+
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./Fraud_Detection:/app
+    environment:
+      DJANGO_SETTINGS_MODULE: Fraud_Detection.settings
+    command: python manage.py runserver 0.0.0.0:8000

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+python manage.py migrate --noinput
+
+exec "$@"


### PR DESCRIPTION
## Summary
- add a Dockerfile and entrypoint that containerize the Django fraud detection project
- provide a docker-compose configuration and dockerignore for development workflows
- document how to build and run the application in Docker via a new README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de60c7eed88328b055068d490eacce